### PR TITLE
Fixes invalid script tags for office.js that were introduced in aeded50.

### DIFF
--- a/PowerPoint/webapp/Photo.html
+++ b/PowerPoint/webapp/Photo.html
@@ -19,7 +19,7 @@
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
 
     <!--Interim Office.js file used during the preview-->
-    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" s" type="text/javascript"></script>
+    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
     <script>
         // The initialize function must be run each time a new page is loaded
         (function () {

--- a/Simple/Webapp/FunctionFile.html
+++ b/Simple/Webapp/FunctionFile.html
@@ -10,7 +10,7 @@
 
     <title></title>
 
-    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" s" type="text/javascript"></script>
+    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
     
     <script>
         // The initialize function must be run each time a new page is loaded

--- a/Simple/Webapp/Taskpane.html
+++ b/Simple/Webapp/Taskpane.html
@@ -19,7 +19,7 @@
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
 
     <!--Office.js-->
-    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" s" type="text/javascript"></script>
+    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
     <script>
         // The initialize function must be run each time a new page is loaded
         (function () {

--- a/Simple/Webapp/Taskpane2.html
+++ b/Simple/Webapp/Taskpane2.html
@@ -17,7 +17,7 @@
     <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
 
     <!--Office.js-->
-    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" s" type="text/javascript"></script>
+    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js" type="text/javascript"></script>
     <script>
         // The initialize function must be run each time a new page is loaded
         (function () {


### PR DESCRIPTION
Seems like a thing introduced by search and replace.
